### PR TITLE
updated dynamic sql section

### DIFF
--- a/SQL-Performance-Baseline/CREATEOBJECTS.sql
+++ b/SQL-Performance-Baseline/CREATEOBJECTS.sql
@@ -519,6 +519,7 @@ IF  NOT EXISTS (SELECT * FROM sys.objects WHERE object_id = OBJECT_ID(N'[spLoadS
 		END
 GO
 
+　
 IF  EXISTS (SELECT * FROM sys.objects WHERE object_id = OBJECT_ID(N'[spGetPerfCountersFromPowerShell]') AND type in (N'P', N'PC'))
               BEGIN
                      DROP PROCEDURE dbo.[spGetPerfCountersFromPowerShell]
@@ -539,49 +540,50 @@ CREATE PROCEDURE [dbo].[spGetPerfCountersFromPowerShell]
 AS
 BEGIN
 DECLARE @syscounters NVARCHAR(4000)
-SET @syscounters=STUFF((SELECT DISTINCT ''',''' +LTRIM([counter_name])
+SET @syscounters=STUFF((SELECT DISTINCT '''''','''''' +LTRIM([counter_name])
 FROM [dba_local].[dbo].[PerformanceCounterList]
-WHERE [is_captured_ind] = 1 FOR XML PATH('')), 1, 2, '')+'''' 
+WHERE [is_captured_ind] = 1 FOR XML PATH('''')), 1, 2, '''')+'''''''' 
 
 DECLARE @cmd NVARCHAR(4000)
 DECLARE @syscountertable TABLE (id INT IDENTITY(1,1), [output] VARCHAR(500))
 DECLARE @syscountervaluestable TABLE (id INT IDENTITY(1,1), [value] VARCHAR(500))
 
-SET @cmd = 'C:\WINDOWS\system32\WindowsPowerShell\v1.0\powershell.exe "& get-counter -counter '+ @syscounters +' | Select-Object -ExpandProperty Readings"'
+SET @cmd = ''C:\WINDOWS\system32\WindowsPowerShell\v1.0\powershell.exe "& get-counter -counter ''+ @syscounters +'' | Select-Object -ExpandProperty Readings"''
 INSERT @syscountertable
 EXEC master..xp_cmdshell @cmd
 
 declare @sqlnamedinstance sysname
 declare @networkname sysname
-if (select CHARINDEX('\',@@SERVERNAME)) = 0
-begin
-INSERT [dba_local].[dbo].[PerformanceCounter] (CounterName, CounterValue, DateSampled)
-SELECT  REPLACE(REPLACE(REPLACE(ct.[output],'\\'+@@SERVERNAME+'\',''),' :',''),'sqlserver:','')[CounterName] , CONVERT(varchar(20),ct2.[output]) [CounterValue], GETDATE() [DateSampled]
-FROM @syscountertable ct
-LEFT OUTER JOIN (
-SELECT id - 1 [id], [output]
-FROM @syscountertable
-WHERE PATINDEX('%[0-9]%', LEFT([output],1)) > 0  
-) ct2 ON ct.id = ct2.id
-WHERE  ct.[output] LIKE '\\%'
-ORDER BY [CounterName] ASC
-end
-else
-begin
-select @networkname=RTRIM(left(@@SERVERNAME, CHARINDEX('\', @@SERVERNAME) - 1))
-select @sqlnamedinstance=RIGHT(@@SERVERNAME,CHARINDEX('\',REVERSE(@@SERVERNAME))-1)
-INSERT [dba_local].[dbo].[PerformanceCounter] (CounterName, CounterValue, DateSampled)
-SELECT  REPLACE(REPLACE(REPLACE(ct.[output],'\\'+@networkname+'\',''),' :',''),'mssql$'+@sqlnamedinstance+':','')[CounterName] , CONVERT(varchar(20),ct2.[output]) [CounterValue], GETDATE() [DateSampled]
-FROM @syscountertable ct
-LEFT OUTER JOIN (
-SELECT id - 1 [id], [output]
-FROM @syscountertable
-WHERE PATINDEX('%[0-9]%', LEFT([output],1)) > 0  
-) ct2 ON ct.id = ct2.id
-WHERE  ct.[output] LIKE '\\%'
-ORDER BY [CounterName] ASC
-END
-';
-			PRINT 'Procedure spGetPerfCountersFromPowerShell created on server ' + CAST(SERVERPROPERTY('ServerName') AS VARCHAR(100)) + ' '
+if (select CHARINDEX(''\'',@@SERVERNAME)) = 0
+	begin
+	INSERT [dba_local].[dbo].[PerformanceCounter] (CounterName, CounterValue, DateSampled)
+	SELECT  REPLACE(REPLACE(REPLACE(ct.[output],''\\''+@@SERVERNAME+''\'',''''),'' :'',''''),''sqlserver:'','''')[CounterName] , CONVERT(varchar(20),ct2.[output]) [CounterValue], GETDATE() [DateSampled]
+	FROM @syscountertable ct
+	LEFT OUTER JOIN (
+	SELECT id - 1 [id], [output]
+	FROM @syscountertable
+	WHERE PATINDEX(''%[0-9]%'', LEFT([output],1)) > 0  
+	) ct2 ON ct.id = ct2.id
+	WHERE  ct.[output] LIKE ''\\%''
+	ORDER BY [CounterName] ASC
+	end
+
+	else
+	begin
+	select @networkname=RTRIM(left(@@SERVERNAME, CHARINDEX(''\'', @@SERVERNAME) - 1))
+	select @sqlnamedinstance=RIGHT(@@SERVERNAME,CHARINDEX(''\'',REVERSE(@@SERVERNAME))-1)
+	INSERT [dba_local].[dbo].[PerformanceCounter] (CounterName, CounterValue, DateSampled)
+	SELECT  REPLACE(REPLACE(REPLACE(ct.[output],''\\''+@networkname+''\'',''''),'' :'',''''),''mssql$''+@sqlnamedinstance+'':'','''')[CounterName] , CONVERT(varchar(20),ct2.[output]) [CounterValue], GETDATE() [DateSampled]
+	FROM @syscountertable ct
+	LEFT OUTER JOIN (
+	SELECT id - 1 [id], [output]
+	FROM @syscountertable
+	WHERE PATINDEX(''%[0-9]%'', LEFT([output],1)) > 0  
+	) ct2 ON ct.id = ct2.id
+	WHERE  ct.[output] LIKE ''\\%''
+	ORDER BY [CounterName] ASC
+	END
+END';
+PRINT 'Procedure spGetPerfCountersFromPowerShell created on server ' + CAST(SERVERPROPERTY('ServerName') AS VARCHAR(100)) + ' '
 		END
 GO


### PR DESCRIPTION
dynamic SQL section for procedure spGetPerfCountersFromPowerShell wasn't working due to Syntax Errors

I have fixed this section so the CREATEOBJECTS.sql can work as expected again