### PR TITLE
data type change in spLoadSchedulerMonitor

### DIFF
--- a/SQL-Performance-Baseline/CREATEOBJECTS.sql
+++ b/SQL-Performance-Baseline/CREATEOBJECTS.sql
@@ -519,6 +519,7 @@ IF  NOT EXISTS (SELECT * FROM sys.objects WHERE object_id = OBJECT_ID(N'[spLoadS
 		END
 GO
 
+　
 IF  EXISTS (SELECT * FROM sys.objects WHERE object_id = OBJECT_ID(N'[spGetPerfCountersFromPowerShell]') AND type in (N'P', N'PC'))
               BEGIN
                      DROP PROCEDURE dbo.[spGetPerfCountersFromPowerShell]
@@ -539,49 +540,50 @@ CREATE PROCEDURE [dbo].[spGetPerfCountersFromPowerShell]
 AS
 BEGIN
 DECLARE @syscounters NVARCHAR(4000)
-SET @syscounters=STUFF((SELECT DISTINCT ''',''' +LTRIM([counter_name])
+SET @syscounters=STUFF((SELECT DISTINCT '''''','''''' +LTRIM([counter_name])
 FROM [dba_local].[dbo].[PerformanceCounterList]
-WHERE [is_captured_ind] = 1 FOR XML PATH('')), 1, 2, '')+'''' 
+WHERE [is_captured_ind] = 1 FOR XML PATH('''')), 1, 2, '''')+'''''''' 
 
 DECLARE @cmd NVARCHAR(4000)
 DECLARE @syscountertable TABLE (id INT IDENTITY(1,1), [output] VARCHAR(500))
 DECLARE @syscountervaluestable TABLE (id INT IDENTITY(1,1), [value] VARCHAR(500))
 
-SET @cmd = 'C:\WINDOWS\system32\WindowsPowerShell\v1.0\powershell.exe "& get-counter -counter '+ @syscounters +' | Select-Object -ExpandProperty Readings"'
+SET @cmd = ''C:\WINDOWS\system32\WindowsPowerShell\v1.0\powershell.exe "& get-counter -counter ''+ @syscounters +'' | Select-Object -ExpandProperty Readings"''
 INSERT @syscountertable
 EXEC master..xp_cmdshell @cmd
 
 declare @sqlnamedinstance sysname
 declare @networkname sysname
-if (select CHARINDEX('\',@@SERVERNAME)) = 0
-begin
-INSERT [dba_local].[dbo].[PerformanceCounter] (CounterName, CounterValue, DateSampled)
-SELECT  REPLACE(REPLACE(REPLACE(ct.[output],'\\'+@@SERVERNAME+'\',''),' :',''),'sqlserver:','')[CounterName] , CONVERT(varchar(20),ct2.[output]) [CounterValue], GETDATE() [DateSampled]
-FROM @syscountertable ct
-LEFT OUTER JOIN (
-SELECT id - 1 [id], [output]
-FROM @syscountertable
-WHERE PATINDEX('%[0-9]%', LEFT([output],1)) > 0  
-) ct2 ON ct.id = ct2.id
-WHERE  ct.[output] LIKE '\\%'
-ORDER BY [CounterName] ASC
-end
-else
-begin
-select @networkname=RTRIM(left(@@SERVERNAME, CHARINDEX('\', @@SERVERNAME) - 1))
-select @sqlnamedinstance=RIGHT(@@SERVERNAME,CHARINDEX('\',REVERSE(@@SERVERNAME))-1)
-INSERT [dba_local].[dbo].[PerformanceCounter] (CounterName, CounterValue, DateSampled)
-SELECT  REPLACE(REPLACE(REPLACE(ct.[output],'\\'+@networkname+'\',''),' :',''),'mssql$'+@sqlnamedinstance+':','')[CounterName] , CONVERT(varchar(20),ct2.[output]) [CounterValue], GETDATE() [DateSampled]
-FROM @syscountertable ct
-LEFT OUTER JOIN (
-SELECT id - 1 [id], [output]
-FROM @syscountertable
-WHERE PATINDEX('%[0-9]%', LEFT([output],1)) > 0  
-) ct2 ON ct.id = ct2.id
-WHERE  ct.[output] LIKE '\\%'
-ORDER BY [CounterName] ASC
-END
-';
-			PRINT 'Procedure spGetPerfCountersFromPowerShell created on server ' + CAST(SERVERPROPERTY('ServerName') AS VARCHAR(100)) + ' '
+if (select CHARINDEX(''\'',@@SERVERNAME)) = 0
+	begin
+	INSERT [dba_local].[dbo].[PerformanceCounter] (CounterName, CounterValue, DateSampled)
+	SELECT  REPLACE(REPLACE(REPLACE(ct.[output],''\\''+@@SERVERNAME+''\'',''''),'' :'',''''),''sqlserver:'','''')[CounterName] , CONVERT(varchar(20),ct2.[output]) [CounterValue], GETDATE() [DateSampled]
+	FROM @syscountertable ct
+	LEFT OUTER JOIN (
+	SELECT id - 1 [id], [output]
+	FROM @syscountertable
+	WHERE PATINDEX(''%[0-9]%'', LEFT([output],1)) > 0  
+	) ct2 ON ct.id = ct2.id
+	WHERE  ct.[output] LIKE ''\\%''
+	ORDER BY [CounterName] ASC
+	end
+
+	else
+	begin
+	select @networkname=RTRIM(left(@@SERVERNAME, CHARINDEX(''\'', @@SERVERNAME) - 1))
+	select @sqlnamedinstance=RIGHT(@@SERVERNAME,CHARINDEX(''\'',REVERSE(@@SERVERNAME))-1)
+	INSERT [dba_local].[dbo].[PerformanceCounter] (CounterName, CounterValue, DateSampled)
+	SELECT  REPLACE(REPLACE(REPLACE(ct.[output],''\\''+@networkname+''\'',''''),'' :'',''''),''mssql$''+@sqlnamedinstance+'':'','''')[CounterName] , CONVERT(varchar(20),ct2.[output]) [CounterValue], GETDATE() [DateSampled]
+	FROM @syscountertable ct
+	LEFT OUTER JOIN (
+	SELECT id - 1 [id], [output]
+	FROM @syscountertable
+	WHERE PATINDEX(''%[0-9]%'', LEFT([output],1)) > 0  
+	) ct2 ON ct.id = ct2.id
+	WHERE  ct.[output] LIKE ''\\%''
+	ORDER BY [CounterName] ASC
+	END
+END';
+PRINT 'Procedure spGetPerfCountersFromPowerShell created on server ' + CAST(SERVERPROPERTY('ServerName') AS VARCHAR(100)) + ' '
 		END
 GO

--- a/SQL-Performance-Baseline/README.md
+++ b/SQL-Performance-Baseline/README.md
@@ -29,3 +29,15 @@ You can follow the steps mentioned below  to set it up in your environment.
 1.	Deploy the SSRS Reports & see if data populates in the reports.
 
 _DISCLAIMER_: © 2016 Microsoft Corporation. All rights reserved. Sample scripts in this guide are not supported under any Microsoft standard support program or service. The sample scripts are provided AS IS without warranty of any kind. Microsoft disclaims all implied warranties including, without limitation, any implied warranties of merchantability or of fitness for a particular purpose. The entire risk arising out of the use or performance of the sample scripts and documentation remains with you. In no event shall Microsoft, its authors, or anyone else involved in the creation, production, or delivery of the scripts be liable for any damages whatsoever (including, without limitation, damages for loss of business profits, business interruption, loss of business information, or other pecuniary loss) arising out of the use of or inability to use the sample scripts or documentation, even if Microsoft has been advised of the possibility of such damages.
+
+### Changes
+
+Date: 2017/05/12
+Author: Dirk Hondong
+affected script: CreateSystemhealthDBandSchema.sql
+affected proc: dbo.spLoadSchedulerMonitor
+Change: data type change from int to bigint 
+c1.value('(./event/data[@name="id"])[1]', 'int') as [id]  
+to 
+c1.value('(./event/data[@name="id"])[1]', 'bigint') as [id]
+to avoid overflow error

--- a/SQL-Performance-Baseline/README.md
+++ b/SQL-Performance-Baseline/README.md
@@ -1,4 +1,4 @@
- 
+
 # SQL Performance Baseline
 
 A recording of the webinar which talks about this solution is available on [YouTube](https://www.youtube.com/watch?v=bx_NGNEz94k)
@@ -30,7 +30,7 @@ You can follow the steps mentioned below  to set it up in your environment.
 
 _DISCLAIMER_: © 2016 Microsoft Corporation. All rights reserved. Sample scripts in this guide are not supported under any Microsoft standard support program or service. The sample scripts are provided AS IS without warranty of any kind. Microsoft disclaims all implied warranties including, without limitation, any implied warranties of merchantability or of fitness for a particular purpose. The entire risk arising out of the use or performance of the sample scripts and documentation remains with you. In no event shall Microsoft, its authors, or anyone else involved in the creation, production, or delivery of the scripts be liable for any damages whatsoever (including, without limitation, damages for loss of business profits, business interruption, loss of business information, or other pecuniary loss) arising out of the use of or inability to use the sample scripts or documentation, even if Microsoft has been advised of the possibility of such damages.
 
-### Changes Notes
+### Change Notes
 
 Date: 2017/05/12
 Author: Dirk Hondong

--- a/SQL-Performance-Baseline/README.md
+++ b/SQL-Performance-Baseline/README.md
@@ -1,4 +1,4 @@
-
+ 
 # SQL Performance Baseline
 
 A recording of the webinar which talks about this solution is available on [YouTube](https://www.youtube.com/watch?v=bx_NGNEz94k)
@@ -30,12 +30,12 @@ You can follow the steps mentioned below  to set it up in your environment.
 
 _DISCLAIMER_: © 2016 Microsoft Corporation. All rights reserved. Sample scripts in this guide are not supported under any Microsoft standard support program or service. The sample scripts are provided AS IS without warranty of any kind. Microsoft disclaims all implied warranties including, without limitation, any implied warranties of merchantability or of fitness for a particular purpose. The entire risk arising out of the use or performance of the sample scripts and documentation remains with you. In no event shall Microsoft, its authors, or anyone else involved in the creation, production, or delivery of the scripts be liable for any damages whatsoever (including, without limitation, damages for loss of business profits, business interruption, loss of business information, or other pecuniary loss) arising out of the use of or inability to use the sample scripts or documentation, even if Microsoft has been advised of the possibility of such damages.
 
-### Changes
+### Changes Notes
 
 Date: 2017/05/12
 Author: Dirk Hondong
-affected script: CreateSystemhealthDBandSchema.sql
-affected proc: dbo.spLoadSchedulerMonitor
+Affected script: CreateSystemhealthDBandSchema.sql
+Affected proc: dbo.spLoadSchedulerMonitor
 Change: data type change from int to bigint 
 c1.value('(./event/data[@name="id"])[1]', 'int') as [id]  
 to 


### PR DESCRIPTION
Change of  c1.value('(./event/data[@name="id"])[1]', 'int') as id,  to c1.value('(./event/data[@name="id"])[1]', 'bigint') as id,
to avoid overflow Errors as described in https://github.com/Microsoft/tigertoolbox/issues/44 