### PR TITLE
Adding check for HP/Windows processor issue

### DIFF
--- a/BPCheck/Check_BP_Servers.sql
+++ b/BPCheck/Check_BP_Servers.sql
@@ -5131,7 +5131,7 @@ EXEC ('DBCC TRACESTATUS WITH NO_INFOMSGS')
 
 IF @sqlmajorver >= 11
 BEGIN
-	DECLARE @dbname0 NVARCHAR(1000), @dbid0 int, @sqlcmd0 NVARCHAR(4000), @has_colstrix int
+	DECLARE @dbname0 NVARCHAR(1000), @dbid0 int, @sqlcmd0 NVARCHAR(4000), @has_colstrix int, @min_compat_level tinyint
 
 	IF EXISTS (SELECT [object_id] FROM tempdb.sys.objects (NOLOCK) WHERE [object_id] = OBJECT_ID('tempdb.dbo.#tblColStoreIXs'))
 	DROP TABLE #tblColStoreIXs;
@@ -5180,6 +5180,9 @@ WHERE i.[type] IN (5,6,7)' -- 5 = Clustered columnstore; 6 = Nonclustered column
 	END;
 	
 	SELECT @has_colstrix = COUNT(*) FROM #tblColStoreIXs
+
+	SELECT @min_compat_level = min([compatibility_level]) from #tmpdbs0
+
 END;
 
 IF (SELECT COUNT(TraceFlag) FROM @tracestatus WHERE [Global]=1) = 0
@@ -5238,7 +5241,7 @@ BEGIN
 						OR (@sqlmajorver = 9 AND @sqlbuild >= 4226))
 					THEN '[INFORMATION: TF845 supports locking pages in memory in SQL Server Standard Editions]'
 				WHEN SERVERPROPERTY('EngineEdition') = 2 --Standard SKU
-					AND @sqlmajorver = 11
+					AND @sqlmajorver >= 11 
 					THEN '[WARNING: TF845 is not needed in SQL 2012 and above]'
 			ELSE '[WARNING: Verify need to set a Non-default TF with current system build and configuration]'
 			END AS [Deviation], TraceFlag
@@ -5254,12 +5257,13 @@ BEGIN
 		FROM @tracestatus 
 		WHERE [Global] = 1 AND TraceFlag = 902
 	END;
-	
 	IF EXISTS (SELECT TraceFlag FROM @tracestatus WHERE [Global] = 1 AND TraceFlag = 1117)
 	BEGIN
 		SELECT 'Instance_checks' AS [Category], 'Global_Trace_Flags' AS [Check], 
-			'[INFORMATION: TF1117 autogrows all files at the same time and affects all databases]' 
-			AS [Deviation], TraceFlag
+		CASE WHEN @sqlmajorver >= 13 --SQL 2016
+			THEN '[WARNING: TF1117 is not needed in SQL 2016 and above]'
+			ELSE '[INFORMATION: TF1117 autogrows all files at the same time and affects all databases]' 
+		END AS [Deviation], TraceFlag
 		FROM @tracestatus 
 		WHERE [Global] = 1 AND TraceFlag = 1117
 	END;
@@ -5267,12 +5271,13 @@ BEGIN
 	IF EXISTS (SELECT TraceFlag FROM @tracestatus WHERE [Global] = 1 AND TraceFlag = 1118)
 	BEGIN
 		SELECT 'Instance_checks' AS [Category], 'Global_Trace_Flags' AS [Check],
-			'[INFORMATION: TF1118 forces uniform extent allocations instead of mixed page allocations]'
-			AS [Deviation], TraceFlag
+		CASE WHEN @sqlmajorver >= 13 --SQL 2016
+			THEN '[WARNING: TF1118 is not needed in SQL 2016 and above]'
+			ELSE '[INFORMATION: TF1118 forces uniform extent allocations instead of mixed page allocations]'
+		END AS [Deviation], TraceFlag
 		FROM @tracestatus 
 		WHERE [Global] = 1 AND TraceFlag = 1118
 	END;
-
 	IF EXISTS (SELECT TraceFlag FROM @tracestatus WHERE [Global] = 1 AND TraceFlag = 1204)
 	BEGIN
 		SELECT 'Instance_checks' AS [Category], 'Global_Trace_Flags' AS [Check],
@@ -5367,11 +5372,11 @@ BEGIN
 	BEGIN
 		SELECT 'Instance_checks' AS [Category], 'Global_Trace_Flags' AS [Check],
 			CASE WHEN @sqlmajorver >= 9
-				AND @maxservermem >= 100000 * 1024 -- 100GB
+				AND @maxservermem >= 102400 -- 100GB
 				AND @maxservermem <> 2147483647
 				THEN '[INFORMATION: TF2335 assumes a fixed amount of memory is available during query optimization. Recommended when server has more than 100GB of memory]'
 			WHEN @sqlmajorver >= 9
-				AND @maxservermem < 100000 * 1024 -- 100GB
+				AND @maxservermem < 102400 -- 100GB
 				AND @maxservermem <> 2147483647
 				THEN '[WARNING: TF2335 should not be set on servers with less than 100GB of memory]'
 			ELSE '[WARNING: Verify need to set a Non-default TF with current system build and configuration]'
@@ -5382,7 +5387,7 @@ BEGIN
 	
 	IF NOT EXISTS (SELECT TraceFlag FROM @tracestatus WHERE [Global] = 1 AND TraceFlag = 2335)
 		AND @sqlmajorver >= 9
-		AND @maxservermem >= 100000 * 1024 -- 100GB
+		AND @maxservermem >= 102400 -- 100GB
 		AND @maxservermem <> 2147483647
 	BEGIN
 		SELECT 'Instance_checks' AS [Category], 'Global_Trace_Flags' AS [Check], 
@@ -5402,10 +5407,11 @@ BEGIN
 	IF EXISTS (SELECT TraceFlag FROM @tracestatus WHERE [Global] = 1 AND TraceFlag = 2371)
 	BEGIN
 		SELECT 'Instance_checks' AS [Category], 'Global_Trace_Flags' AS [Check],
-			CASE WHEN (@sqlmajorver = 10 AND @sqlminorver = 50 AND @sqlbuild >= 2500) OR @sqlmajorver >= 11
+			CASE WHEN (@sqlmajorver = 10 AND @sqlminorver = 50 AND @sqlbuild >= 2500) OR @sqlmajorver BETWEEN 11 AND 12 OR (@sqlmajorver >= 13 AND @min_compat_level < 130)
 				THEN '[INFORMATION: TF2371 changes the fixed rate of the 20pct threshold for update statistics into a dynamic percentage rate]'
-			WHEN @sqlmajorver >= 13
-				THEN '[WARNING: TF2371 is not needed in SQL 2016 and above]'
+			WHEN @sqlmajorver >= 13 AND @min_compat_level >= 130
+				--TF2371 has no effect if all databases are at least at compatibility level 130.
+				THEN '[WARNING: TF2371 is not needed in SQL 2016 and above when all databases are at compatibility level 130 and above]'
 			ELSE '[WARNING: Verify need to set a Non-default TF with current system build and configuration]'
 			END AS [Deviation], TraceFlag
 		FROM @tracestatus 
@@ -5413,7 +5419,7 @@ BEGIN
 	END;
 	
 	IF NOT EXISTS (SELECT TraceFlag FROM @tracestatus WHERE [Global] = 1 AND TraceFlag = 2371)
-		AND ((@sqlmajorver = 10 AND @sqlminorver = 50 AND @sqlbuild >= 2500) OR @sqlmajorver >= 11)
+		AND ((@sqlmajorver = 10 AND @sqlminorver = 50 AND @sqlbuild >= 2500) OR @sqlmajorver BETWEEN 11 AND 12 OR (@sqlmajorver >= 13 AND @min_compat_level < 130))
 	BEGIN
 		SELECT 'Instance_checks' AS [Category], 'Global_Trace_Flags' AS [Check], 
 			'[INFORMATION: Consider enabling TF2371 to change the 20pct fixed rate threshold for update statistics into a dynamic percentage rate]' --http://blogs.msdn.com/b/saponsqlserver/archive/2011/09/07/changes-to-automatic-update-statistics-in-sql-server-traceflag-2371.aspx

--- a/Waits-and-Latches/view_Waits.sql
+++ b/Waits-and-Latches/view_Waits.sql
@@ -174,7 +174,7 @@ SELECT 'Waits_last_' + CONVERT(VARCHAR(3), @duration) + 's' AS [Information], W1
 		WHEN W1.wait_type = N'REPLICA_WRITE' THEN 'Snapshots'
 		WHEN W1.wait_type = N'WAIT_XTP_OFFLINE_CKPT_LOG_IO' OR W1.wait_type = N'WAIT_XTP_CKPT_CLOSE' THEN 'In-Memory OLTP Logging'
 		WHEN W1.wait_type LIKE N'QDS%' THEN N'Query Store'
-		WHEN W1.wait_type LIKE N'XTP%' OR wait_type LIKE N'WAIT_XTP%' THEN N'In-Memory OLTP'
+		WHEN W1.wait_type LIKE N'XTP%' OR W1.wait_type LIKE N'WAIT_XTP%' THEN N'In-Memory OLTP'
 		WHEN W1.wait_type LIKE N'PARALLEL_REDO%' THEN N'Parallel Redo'
 		WHEN W1.wait_type LIKE N'COLUMNSTORE%' THEN N'Columnstore'
 	ELSE N'Other' END AS 'wait_category'


### PR DESCRIPTION
Check implemented as outlined in support article from HP (https://support.hpe.com/hpsc/doc/public/display?docId=emr_na-c04650594). 

Ignoring Gen9 specification in advisory headline, as the Hardware Platforms Affected section also mentions Gen8.