### PR TITLE
Overflow with `sample_ms` as `INT`

### DIFF
--- a/BPCheck/Check_BP_Servers.sql
+++ b/BPCheck/Check_BP_Servers.sql
@@ -2840,7 +2840,7 @@ BEGIN
 	DROP TABLE #tmp_dm_io_virtual_file_stats;
 	IF NOT EXISTS (SELECT [object_id] FROM tempdb.sys.objects (NOLOCK) WHERE [object_id] = OBJECT_ID('tempdb.dbo.#tmp_dm_io_virtual_file_stats'))	
 	CREATE TABLE [dbo].[#tmp_dm_io_virtual_file_stats]([retrieval_time] [datetime],database_id int, [file_id] int, [DBName] sysname, [logical_file_name] NVARCHAR(255), [type_desc] NVARCHAR(60), 
-		[physical_location] NVARCHAR(260),[sample_ms] int,[num_of_reads] bigint,[num_of_bytes_read] bigint,[io_stall_read_ms] bigint,[num_of_writes] bigint,
+		[physical_location] NVARCHAR(260),[sample_ms] bigint,[num_of_reads] bigint,[num_of_bytes_read] bigint,[io_stall_read_ms] bigint,[num_of_writes] bigint,
 		[num_of_bytes_written] bigint,[io_stall_write_ms] bigint,[io_stall] bigint,[size_on_disk_bytes] bigint,
 		CONSTRAINT PK_dm_io_virtual_file_stats PRIMARY KEY CLUSTERED(database_id, [file_id], [retrieval_time]));
 


### PR DESCRIPTION
In the **I/O Checks** section, `#tmp_dm_io_virtual_file_stats` inserts can overflow on `sample_ms`.

Sample errors:
`Msg 8115, Level 16, State 2, Line 2858`
`Arithmetic overflow error converting expression to data type int.`
`The statement has been terminated.`
`Msg 8115, Level 16, State 2, Line 2878`
`Arithmetic overflow error converting expression to data type int.`
`The statement has been terminated.`