### PR TITLE
Fix #67

### DIFF
--- a/MaintenanceSolution/4_job_AdaptiveCycleErrorlog.sql
+++ b/MaintenanceSolution/4_job_AdaptiveCycleErrorlog.sql
@@ -69,6 +69,7 @@ EXEC @ReturnCode = msdb.dbo.sp_add_jobstep @job_id=@jobId, @step_name=N'Adaptive
 		@retry_interval=0, 
 		@os_run_priority=0, @subsystem=N'TSQL', 
 		@command=N'SET NOCOUNT ON;
+SET DATEFORMAT mdy;
 DECLARE @CycleMessage VARCHAR(255), @return_value int, @Output VARCHAR(32)
 DECLARE @ErrorLogs TABLE (ArchiveNumber tinyint, DateCreated DATETIME, LogFileSizeBytes int)
 INSERT into @ErrorLogs (ArchiveNumber, DateCreated, LogFileSizeBytes )


### PR DESCRIPTION
Setting xp_enumerrorlogs date format as default, and because of that you are now able to keep any language configuration.