### PR TITLE
Fixed overlapping WHEN cases in bpcheck.

### DIFF
--- a/BPCheck/Check_BP_Servers.sql
+++ b/BPCheck/Check_BP_Servers.sql
@@ -5579,8 +5579,8 @@ BEGIN
 	IF EXISTS (SELECT TraceFlag FROM @tracestatus WHERE [Global] = 1 AND TraceFlag = 6498)
 	BEGIN
 		SELECT 'Instance_checks' AS [Category], 'Global_Trace_Flags' AS [Check],
-			CASE WHEN (@sqlmajorver = 12 AND @sqlbuild >= 4416)
-					OR (@sqlmajorver = 12 AND @sqlbuild BETWEEN 2480 AND 2474)
+			CASE WHEN (@sqlmajorver = 12 AND @sqlbuild >= 4416 AND @sqlbuild < 5000)
+					OR (@sqlmajorver = 12 AND @sqlbuild BETWEEN 2474 AND 2480)
 				THEN '[INFORMATION: TF6498 enables more than one large query compilation to gain access to the big gateway when there is sufficient memory available]'
 			WHEN (@sqlmajorver = 12 AND @sqlbuild >= 5000) OR @sqlmajorver >= 13
 				THEN '[WARNING: TF6498 is not needed in SQL 2014 SP2, SQL Server 2016 and above]'


### PR DESCRIPTION
Two cases in current BPCHeck code are overlapping:
```
WHEN (@sqlmajorver = 12 AND @sqlbuild >= 4416) 
     OR (@sqlmajorver = 12 AND @sqlbuild BETWEEN 2480 AND 2474)
     ...
WHEN (@sqlmajorver = 12 AND @sqlbuild >= 5000) OR @sqlmajorver >= 13
     ...
```
In the current version of BPCheck the first branch will still be triggered for versions from 12.0.5000 to 13.0. This does not look like intended behavior for SQL Server 2014 SP2 and SP3. 
This tiny commit fixed this.