### PR TITLE
Update of 5_job_Maintenance.sql for databases in Availability Group

### DIFF
--- a/MaintenanceSolution/5_job_Maintenance.sql
+++ b/MaintenanceSolution/5_job_Maintenance.sql
@@ -942,8 +942,15 @@ BEGIN
 	CREATE TABLE #tmpdbs (id int IDENTITY(1,1), [dbname] sysname, isdone bit)
 
 	INSERT INTO #tmpdbs ([dbname], isdone)
-	SELECT QUOTENAME(d.name), 0 FROM sys.databases d INNER JOIN sys.master_files smf ON d.database_id = smf.database_id
-	WHERE d.is_read_only = 0 AND d.state = 0 AND d.database_id <> 2 AND smf.type = 0 AND (smf.size * 8)/1024 < 4096;
+	(SELECT DISTINCT QUOTENAME(d.name), 0 FROM sys.databases d 
+	INNER JOIN sys.master_files smf ON d.database_id = smf.database_id
+	JOIN sys.dm_hadr_database_replica_states hadrdrs
+	WHERE d.is_read_only = 0 AND d.state = 0 AND d.database_id <> 2 AND smf.type = 0 AND (smf.size * 8)/1024 < 4096 AND hadrdrs.is_primary_replica = 1)
+	UNION
+	(SELECT DISTINCT QUOTENAME(d.name), 0 FROM sys.databases d 
+	INNER JOIN sys.master_files smf ON d.database_id = smf.database_id
+	LEFT JOIN sys.dm_hadr_database_replica_states hadrdrs
+	WHERE d.is_read_only = 0 AND d.state = 0 AND d.database_id <> 2 AND smf.type = 0 AND (smf.size * 8)/1024 < 4096 AND hadrdrs.database_id IS NULL);
 
 	WHILE (SELECT COUNT([dbname]) FROM #tmpdbs WHERE isdone = 0) > 0
 	BEGIN
@@ -1003,7 +1010,9 @@ BEGIN
 	CREATE TABLE #tmpdbs (id int IDENTITY(1,1), [dbname] sysname, isdone bit)
 
 	INSERT INTO #tmpdbs ([dbname], isdone)
-	SELECT QUOTENAME(name), 0 FROM sys.databases WHERE is_read_only = 0 AND state = 0 AND database_id > 4 AND is_distributor = 0;
+	(SELECT QUOTENAME(name), 0 FROM sys.databases JOIN sys.dm_hadr_database_replica_states hadrdrs ON d.database_id = hadrdrs.database_id WHERE is_read_only = 0 AND state = 0 AND database_id > 4 AND is_distributor = 0 AND hadrdrs.is_primary_replica = 1)
+	UNION
+	(SELECT QUOTENAME(name), 0 FROM sys.databases LEFT JOIN sys.dm_hadr_database_replica_states hadrdrs ON d.database_id = hadrdrs.database_id WHERE is_read_only = 0 AND state = 0 AND database_id > 4 AND is_distributor = 0 AND hadrdrs.database_id IS NULL);
 
 	WHILE (SELECT COUNT([dbname]) FROM #tmpdbs WHERE isdone = 0) > 0
 	BEGIN


### PR DESCRIPTION
Fixed issue when database is part of Availability Group and job is failing on secondary replicas