### PR TITLE
HA for Managed Instance

### DIFF
--- a/BPCheck/Check_BP_Servers.sql
+++ b/BPCheck/Check_BP_Servers.sql
@@ -947,6 +947,11 @@ BEGIN
 	SELECT @IsHadrEnabled = CONVERT(tinyint, SERVERPROPERTY('IsHadrEnabled'))
 	SELECT @HadrManagerStatus = CONVERT(tinyint, SERVERPROPERTY('HadrManagerStatus'))
 	
+	IF (SERVERPROPERTY('EngineEdition')=8) BEGIN
+		SET @IsHadrEnabled = 1;
+		SET @HadrManagerStatus = 1;
+	END
+
 	SELECT 'Information' AS [Category], 'AlwaysOn_AG' AS [Information], 
 		CASE @IsHadrEnabled WHEN 0 THEN 'Disabled'
 			WHEN 1 THEN 'Enabled' END AS [AlwaysOn_Availability_Groups],


### PR DESCRIPTION
Due to the bug in Managed Instance `bp_check` is showing that there is not HA. This is "fixed" by explicitly setting the IsHadrenabled = 1 if EngineEdition is 8. 

This change should be removed once SERVERPROPERTY in managed instance is fixed (still not ETA)

