### PR TITLE
Remove duplicate entry

### DIFF
--- a/MaintenanceSolution/0_database_server_options.sql
+++ b/MaintenanceSolution/0_database_server_options.sql
@@ -21,9 +21,6 @@ IF CONVERT(int, (@@microsoftversion / 0x1000000) & 0xff) >= 10
 EXEC sys.sp_configure N'optimize for ad hoc workloads', N'1'
 RECONFIGURE WITH OVERRIDE
 GO
-EXEC sys.sp_configure N'show advanced options', N'0'
-RECONFIGURE WITH OVERRIDE
-GO
 
 USE [master]
 GO


### PR DESCRIPTION
An extra `show advanced options` disable occurs mid-script at line 24.  Setting `max degree of parallelism` requires this to remain enabled until completion, so it has been removed.

`Show advanced options` is still reset at script's end.