### PR TITLE
Fix missing database aliases

### DIFF
--- a/MaintenanceSolution/5_job_Maintenance.sql
+++ b/MaintenanceSolution/5_job_Maintenance.sql
@@ -1010,9 +1010,9 @@ BEGIN
 	CREATE TABLE #tmpdbs (id int IDENTITY(1,1), [dbname] sysname, isdone bit)
 
 	INSERT INTO #tmpdbs ([dbname], isdone)
-	(SELECT QUOTENAME(name), 0 FROM sys.databases JOIN sys.dm_hadr_database_replica_states hadrdrs ON d.database_id = hadrdrs.database_id WHERE is_read_only = 0 AND state = 0 AND database_id > 4 AND is_distributor = 0 AND hadrdrs.is_primary_replica = 1)
+	(SELECT QUOTENAME(name), 0 FROM sys.databases d JOIN sys.dm_hadr_database_replica_states hadrdrs ON d.database_id = hadrdrs.database_id WHERE is_read_only = 0 AND state = 0 AND d.database_id > 4 AND is_distributor = 0 AND hadrdrs.is_primary_replica = 1)
 	UNION
-	(SELECT QUOTENAME(name), 0 FROM sys.databases LEFT JOIN sys.dm_hadr_database_replica_states hadrdrs ON d.database_id = hadrdrs.database_id WHERE is_read_only = 0 AND state = 0 AND database_id > 4 AND is_distributor = 0 AND hadrdrs.database_id IS NULL);
+	(SELECT QUOTENAME(name), 0 FROM sys.databases d LEFT JOIN sys.dm_hadr_database_replica_states hadrdrs ON d.database_id = hadrdrs.database_id WHERE is_read_only = 0 AND state = 0 AND d.database_id > 4 AND is_distributor = 0 AND hadrdrs.database_id IS NULL);
 
 	WHILE (SELECT COUNT([dbname]) FROM #tmpdbs WHERE isdone = 0) > 0
 	BEGIN


### PR DESCRIPTION
The "Weekly Maintenance" task was failing in Step 3.

`Date		28/11/2019 1:00:01 AM
Log		Job History (Weekly Maintenance)

Step ID		3
Server		SQL01
Job Name		Weekly Maintenance
Step Name		sp_createstats
Duration		00:00:00
Sql Severity	16
Sql Message ID	209
Operator Emailed	
Operator Net sent	
Operator Paged	
Retries Attempted	0

Message
Executed as user: FOREST\sqlservice. The multi-part identifier "d.database_id" could not be bound. [SQLSTATE 42000] (Error 4104)  Ambiguous column name 'database_id'. [SQLSTATE 42000] (Error 209)  The multi-part identifier "d.database_id" could not be bound. [SQLSTATE 42000] (Error 4104)  Ambiguous column name 'database_id'. [SQLSTATE 42000] (Error 209).  The step failed.
`