### PR TITLE
AG secondary fix, fixed issue with big dbs

### DIFF
--- a/MaintenanceSolution/5_job_Maintenance_MEA.sql
+++ b/MaintenanceSolution/5_job_Maintenance_MEA.sql
@@ -113,7 +113,7 @@ SELECT @sqlmajorver = CONVERT(int, (@@microsoftversion / 0x1000000) & 0xff);
 SELECT @Message = '** Start: ' + CONVERT(VARCHAR, GETDATE())
 RAISERROR(@Message, 0, 42) WITH NOWAIT;
 
-SET @sqlcmd_AO = 'SELECT sd.database_id, sd.name, SUM((size * 8) / 1024) AS rows_size_MB, 0 
+SET @sqlcmd_AO = 'SELECT sd.database_id, sd.name, SUM((cast(size as bigint) * 8) / 1024) AS rows_size_MB, 0 
 FROM sys.databases sd (NOLOCK)
 INNER JOIN sys.master_files smf (NOLOCK) ON sd.database_id = smf.database_id
 WHERE sd.is_read_only = 0 AND sd.state = 0 AND sd.database_id <> 2 AND smf.[type] = 0';
@@ -938,8 +938,15 @@ BEGIN
 	CREATE TABLE #tmpdbs (id int IDENTITY(1,1), [dbname] sysname, isdone bit)
 
 	INSERT INTO #tmpdbs ([dbname], isdone)
-	SELECT QUOTENAME(d.name), 0 FROM sys.databases d INNER JOIN sys.master_files smf ON d.database_id = smf.database_id
-	WHERE d.is_read_only = 0 AND d.state = 0 AND d.database_id <> 2 AND smf.type = 0 AND (smf.size * 8)/1024 < 4096;
+	(SELECT DISTINCT QUOTENAME(d.name), 0 FROM sys.databases d 
+	INNER JOIN sys.master_files smf ON d.database_id = smf.database_id
+	JOIN sys.dm_hadr_database_replica_states hadrdrs ON d.database_id = hadrdrs.database_id
+	WHERE d.is_read_only = 0 AND d.state = 0 AND d.database_id <> 2 AND smf.type = 0 AND (smf.size * 8)/1024 < 4096 AND hadrdrs.is_primary_replica = 1)
+	UNION
+	(SELECT DISTINCT QUOTENAME(d.name), 0 FROM sys.databases d 
+	INNER JOIN sys.master_files smf ON d.database_id = smf.database_id
+	LEFT JOIN sys.dm_hadr_database_replica_states hadrdrs ON d.database_id = hadrdrs.database_id
+	WHERE d.is_read_only = 0 AND d.state = 0 AND d.database_id <> 2 AND smf.type = 0 AND (smf.size * 8)/1024 < 4096 AND hadrdrs.database_id IS NULL);
 
 	WHILE (SELECT COUNT([dbname]) FROM #tmpdbs WHERE isdone = 0) > 0
 	BEGIN
@@ -999,7 +1006,9 @@ BEGIN
 	CREATE TABLE #tmpdbs (id int IDENTITY(1,1), [dbname] sysname, isdone bit)
 
 	INSERT INTO #tmpdbs ([dbname], isdone)
-	SELECT QUOTENAME(name), 0 FROM sys.databases WHERE is_read_only = 0 AND state = 0 AND database_id > 4 AND is_distributor = 0;
+	(SELECT QUOTENAME(name), 0 FROM sys.databases JOIN sys.dm_hadr_database_replica_states hadrdrs ON d.database_id = hadrdrs.database_id WHERE is_read_only = 0 AND state = 0 AND database_id > 4 AND is_distributor = 0 AND hadrdrs.is_primary_replica = 1)
+	UNION
+	(SELECT QUOTENAME(name), 0 FROM sys.databases LEFT JOIN sys.dm_hadr_database_replica_states hadrdrs ON d.database_id = hadrdrs.database_id WHERE is_read_only = 0 AND state = 0 AND database_id > 4 AND is_distributor = 0 AND hadrdrs.database_id IS NULL);
 
 	WHILE (SELECT COUNT([dbname]) FROM #tmpdbs WHERE isdone = 0) > 0
 	BEGIN


### PR DESCRIPTION
Fixed issue when a database is part of Availability Group and job is failing on secondary replicas
Fixed issue with size calculation for bigger databases causing the error: Msg 8115, Sev 16, State 2, Line 1 : Arithmetic overflow error converting expression to data type int. [SQLSTATE 22003].
The change is from int to bigint.