### PR TITLE
fileid is a smallint based on sys.dm_db_log_info

### DIFF
--- a/Fixing-VLFs/Fix_VLFs.sql
+++ b/Fixing-VLFs/Fix_VLFs.sql
@@ -35,7 +35,7 @@ FETCH NEXT FROM csr INTO @dbname
 WHILE (@@FETCH_STATUS <> -1)
 BEGIN
 	CREATE TABLE #log_info (recoveryunitid int NULL,
-	fileid tinyint,
+	fileid smallint,
 	file_size bigint,
 	start_offset bigint,
 	FSeqNo int,


### PR DESCRIPTION
One of my customers has more than 800 files per database and the script crashes with tinyint