### PR TITLE
fileid is a smallint based on sys.dm_db_log_info

### DIFF
--- a/BPCheck/Check_BP_Servers.sql
+++ b/BPCheck/Check_BP_Servers.sql
@@ -6701,7 +6701,7 @@ BEGIN
 				DROP TABLE #log_info3;
 				IF NOT EXISTS (SELECT [object_id] FROM tempdb.sys.objects (NOLOCK) WHERE [object_id] = OBJECT_ID('tempdb.dbo.#log_info3'))
 				CREATE TABLE #log_info3 (recoveryunitid int NULL,
-					fileid tinyint,
+					fileid smallint,
 					file_size bigint,
 					start_offset bigint,
 					FSeqNo int,


### PR DESCRIPTION
One of my customers has more than 800 files per database and the script crashes with tinyint